### PR TITLE
feat: create shared types package with Zod validation

### DIFF
--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -1,5 +1,6 @@
 import { StatusBar } from "expo-status-bar";
 import { StyledView, StyledText, StyledButton, theme } from "@repo/ui";
+import { TypesDemo } from "../components/TypesDemo";
 
 export default function Native() {
   return (
@@ -9,7 +10,6 @@ export default function Native() {
       alignItems="center"
       justifyContent="center"
       padding="lg"
-      margin={0}
       style={{}}
     >
       <StyledText size="4xl" fontWeight="bold" marginBottom="lg" style={{}}>
@@ -41,6 +41,9 @@ export default function Native() {
       >
         Boop
       </StyledButton>
+
+      <TypesDemo />
+
       <StatusBar style="auto" />
     </StyledView>
   );

--- a/apps/native/babel.config.js
+++ b/apps/native/babel.config.js
@@ -4,6 +4,7 @@ module.exports = function (api) {
   return {
     presets: ["babel-preset-expo"],
     plugins: [
+      "expo-router/babel", // Required for expo-router file-based routing
       "react-native-reanimated/plugin", // RN 0.76 ⇒ THIS path, last
     ],
   };

--- a/apps/native/components/TypesDemo.tsx
+++ b/apps/native/components/TypesDemo.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { StyledView, StyledText, StyledButton, theme } from "@repo/ui";
+import {
+  UserSchema,
+  CreateUserSchema,
+  type User,
+  type CreateUser,
+  z,
+} from "@repo/types";
+
+export function TypesDemo() {
+  const [validationResult, setValidationResult] = useState<string>("");
+
+  // Demo user data
+  const validUserData: CreateUser = {
+    email: "john.doe@example.com",
+    username: "johndoe",
+    firstName: "John",
+    lastName: "Doe",
+  };
+
+  const invalidUserData = {
+    email: "invalid-email",
+    username: "jo", // too short
+    firstName: "", // required but empty
+    lastName: "Doe",
+  };
+
+  const validateUser = (data: unknown, isValid: boolean) => {
+    try {
+      const result = CreateUserSchema.parse(data);
+      setValidationResult(`✅ Valid: ${JSON.stringify(result, null, 2)}`);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const errorMessages = error.errors
+          .map((err) => `${err.path.join(".")}: ${err.message}`)
+          .join("\n");
+        setValidationResult(`❌ Invalid:\n${errorMessages}`);
+      } else {
+        setValidationResult(`❌ Unexpected error: ${error}`);
+      }
+    }
+  };
+
+  return (
+    <StyledView padding="lg" backgroundColor={theme.colors.gray[50]}>
+      <StyledText size="xl" fontWeight="bold" marginBottom="md">
+        Shared Types Demo with Zod
+      </StyledText>
+
+      <StyledText marginBottom="sm" color={theme.colors.gray[700]}>
+        Test validation with shared schemas:
+      </StyledText>
+
+      <StyledView style={{ marginBottom: theme.spacing.lg }}>
+        <StyledButton
+          variant="primary"
+          onPress={() => validateUser(validUserData, true)}
+          style={{ marginBottom: theme.spacing.sm }}
+        >
+          Validate Good Data
+        </StyledButton>
+
+        <StyledButton
+          variant="secondary"
+          onPress={() => validateUser(invalidUserData, false)}
+        >
+          Validate Bad Data
+        </StyledButton>
+      </StyledView>
+
+      {validationResult ? (
+        <StyledView
+          backgroundColor={theme.colors.white}
+          padding="md"
+          style={{
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: theme.colors.gray[300],
+          }}
+        >
+          <StyledText
+            size="sm"
+            style={{ fontFamily: "monospace" }}
+            color={theme.colors.gray[800]}
+          >
+            {validationResult}
+          </StyledText>
+        </StyledView>
+      ) : null}
+    </StyledView>
+  );
+}

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -11,6 +11,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@repo/types": "workspace:*",
     "@repo/ui": "workspace:*",
     "expo": "~52.0.46",
     "expo-constants": "~17.0.8",

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,148 @@
+# @repo/types
+
+Shared TypeScript types and Zod schemas for the Questigo monorepo.
+
+## Features
+
+- **Runtime Validation**: All types backed by Zod schemas for runtime type checking
+- **Type Safety**: Full TypeScript support with inferred types
+- **Shared Schemas**: Consistent validation across web and native apps
+- **Tree Shakeable**: Import only what you need
+
+## Installation
+
+This package is automatically available in the monorepo workspace. Import from `@repo/types`:
+
+```typescript
+import { UserSchema, type User, z } from "@repo/types";
+```
+
+## Usage
+
+### User Types
+
+```typescript
+import {
+  UserSchema,
+  CreateUserSchema,
+  type User,
+  type CreateUser,
+} from "@repo/types";
+
+// Validate data at runtime
+const userData = UserSchema.parse(rawData);
+
+// Type-safe user creation
+const newUser: CreateUser = {
+  email: "user@example.com",
+  username: "johndoe",
+  firstName: "John",
+  lastName: "Doe",
+};
+
+// Validate before API calls
+const validatedUser = CreateUserSchema.parse(newUser);
+```
+
+### API Response Types
+
+```typescript
+import {
+  ApiResponseSchema,
+  type ApiResponse,
+  type ApiSuccess,
+} from "@repo/types";
+
+// Type-safe API responses
+function handleApiResponse<T>(response: ApiResponse<T>) {
+  if (response.success) {
+    // TypeScript knows this is ApiSuccess<T>
+    console.log(response.data);
+  } else {
+    // TypeScript knows this is ApiError
+    console.error(response.error);
+  }
+}
+
+// Validate API responses
+const response = ApiResponseSchema.parse(apiData);
+```
+
+### Form Validation
+
+```typescript
+import { RequiredStringSchema, EmailSchema, z } from "@repo/types";
+
+const LoginFormSchema = z.object({
+  email: EmailSchema,
+  password: RequiredStringSchema.min(8),
+});
+
+type LoginForm = z.infer<typeof LoginFormSchema>;
+
+// Use in React Hook Form, Formik, etc.
+const validateLogin = (data: unknown) => {
+  return LoginFormSchema.safeParse(data);
+};
+```
+
+### Common Validation
+
+```typescript
+import { IdSchema, EmailSchema, StatusSchema } from "@repo/types";
+
+// Validate individual fields
+const isValidId = IdSchema.safeParse(userId).success;
+const isValidEmail = EmailSchema.safeParse(email).success;
+const isValidStatus = StatusSchema.safeParse(status).success;
+```
+
+## Available Types
+
+### User Types
+
+- `User` - Complete user object
+- `CreateUser` - User creation payload
+- `UpdateUser` - User update payload (all fields optional)
+
+### API Types
+
+- `ApiResponse<T>` - Generic API response wrapper
+- `ApiSuccess<T>` - Successful API response
+- `ApiError` - Error API response
+- `PaginatedResponse<T>` - Paginated API response
+- `Pagination` - Pagination metadata
+
+### Common Types
+
+- `Id` - UUID string
+- `Email` - Email string
+- `Url` - URL string
+- `DateString` - ISO date string
+- `NodeEnv` - Node environment
+- `Status` - Generic status enum
+- `ValidationError` - Field validation error
+
+## Schemas
+
+All types have corresponding Zod schemas for runtime validation:
+
+- `UserSchema`, `CreateUserSchema`, `UpdateUserSchema`
+- `ApiResponseSchema`, `ApiSuccessSchema`, `ApiErrorSchema`
+- `PaginationSchema`, `PaginatedResponseSchema`
+- `IdSchema`, `EmailSchema`, `UrlSchema`, `DateStringSchema`
+- `RequiredStringSchema`, `OptionalStringSchema`
+- `NodeEnvSchema`, `StatusSchema`, `ValidationErrorSchema`
+
+## Development
+
+```bash
+# Type checking
+pnpm type-check
+
+# Build for production
+pnpm build
+
+# Watch mode
+pnpm dev
+```

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/types",
+  "version": "0.0.0",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "tsup": "^8.0.1",
+    "typescript": "5.5.4"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// API Response types
+export const ApiSuccessSchema = z.object({
+  success: z.literal(true),
+  data: z.unknown(),
+  message: z.string().optional(),
+});
+
+export const ApiErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+  details: z.unknown().optional(),
+});
+
+export const ApiResponseSchema = z.union([ApiSuccessSchema, ApiErrorSchema]);
+
+export type ApiSuccess<T = unknown> = Omit<
+  z.infer<typeof ApiSuccessSchema>,
+  "data"
+> & {
+  data: T;
+};
+
+export type ApiError = z.infer<typeof ApiErrorSchema>;
+export type ApiResponse<T = unknown> = ApiSuccess<T> | ApiError;
+
+// Pagination types
+export const PaginationSchema = z.object({
+  page: z.number().int().positive(),
+  limit: z.number().int().positive().max(100),
+  total: z.number().int().nonnegative(),
+  totalPages: z.number().int().nonnegative(),
+});
+
+export const PaginatedResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.array(z.unknown()),
+  pagination: PaginationSchema,
+});
+
+export type Pagination = z.infer<typeof PaginationSchema>;
+export type PaginatedResponse<T = unknown> = Omit<
+  z.infer<typeof PaginatedResponseSchema>,
+  "data"
+> & {
+  data: T[];
+};

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// Common validation schemas
+export const IdSchema = z.string().uuid();
+export const EmailSchema = z.string().email();
+export const UrlSchema = z.string().url();
+export const DateStringSchema = z.string().datetime();
+
+// Form validation helpers
+export const RequiredStringSchema = z.string().min(1, "This field is required");
+export const OptionalStringSchema = z.string().optional();
+
+// Environment types
+export const NodeEnvSchema = z.enum(["development", "production", "test"]);
+
+// Status types
+export const StatusSchema = z.enum([
+  "active",
+  "inactive",
+  "pending",
+  "archived",
+]);
+
+// Common inferred types
+export type Id = z.infer<typeof IdSchema>;
+export type Email = z.infer<typeof EmailSchema>;
+export type Url = z.infer<typeof UrlSchema>;
+export type DateString = z.infer<typeof DateStringSchema>;
+export type NodeEnv = z.infer<typeof NodeEnvSchema>;
+export type Status = z.infer<typeof StatusSchema>;
+
+// Utility types
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+export type RequiredBy<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+// Error types
+export const ValidationErrorSchema = z.object({
+  field: z.string(),
+  message: z.string(),
+  code: z.string(),
+});
+
+export type ValidationError = z.infer<typeof ValidationErrorSchema>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,17 @@
+// Export all user-related types and schemas
+export * from "./user";
+
+// Export all API-related types and schemas
+export * from "./api";
+
+// Export all common types and schemas
+export * from "./common";
+
+// Export all quest-related types and schemas
+export * from "./quest";
+
+// Export all team-related types and schemas
+export * from "./team";
+
+// Re-export zod for convenience
+export { z } from "zod";

--- a/packages/types/src/quest.ts
+++ b/packages/types/src/quest.ts
@@ -1,0 +1,21 @@
+// packages/types/src/quest.ts
+import { z } from "zod";
+
+export const RiddleSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  prompt: z.string(),
+  lat: z.number(),
+  lng: z.number(),
+  radiusM: z.number().default(30),
+});
+
+export type Riddle = z.infer<typeof RiddleSchema>;
+
+export const QuestSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  riddles: z.array(RiddleSchema).min(1),
+});
+
+export type Quest = z.infer<typeof QuestSchema>;

--- a/packages/types/src/team.ts
+++ b/packages/types/src/team.ts
@@ -1,0 +1,13 @@
+// packages/types/src/team.ts
+import { z } from "zod";
+
+export const TeamSchema = z.object({
+  id: z.string(),
+  code: z.string().min(4),
+  name: z.string(),
+  members: z
+    .array(z.object({ id: z.string(), displayName: z.string() }))
+    .max(4),
+});
+
+export type Team = z.infer<typeof TeamSchema>;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+// User-related types
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  username: z.string().min(3).max(30),
+  firstName: z.string().min(1).max(50),
+  lastName: z.string().min(1).max(50),
+  avatar: z.string().url().optional(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const CreateUserSchema = UserSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const UpdateUserSchema = CreateUserSchema.partial();
+
+export type User = z.infer<typeof UserSchema>;
+export type CreateUser = z.infer<typeof CreateUserSchema>;
+export type UpdateUser = z.infer<typeof UpdateUserSchema>;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   apps/native:
     dependencies:
+      '@repo/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -127,6 +130,22 @@ importers:
       eslint-config-next:
         specifier: 14.0.4
         version: 14.0.4(eslint@8.57.1)(typescript@5.5.4)
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
+  packages/types:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(typescript@5.5.4)(yaml@2.8.1)
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -1075,7 +1094,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -6257,6 +6276,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
@@ -9652,7 +9674,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -9682,7 +9704,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9697,7 +9719,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13470,3 +13492,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
- Add @repo/types package with comprehensive domain schemas
- Implement User, Quest, Team, and Riddle types with Zod validation
- Add API response types and pagination schemas
- Include common validation utilities and error types
- Create TypesDemo component showcasing runtime validation
- Update native app to demonstrate shared types usage
- Add expo-router/babel plugin for proper routing support
- Comprehensive README with usage examples and documentation

Domain Types:
- User: authentication and profile management
- Team: collaborative groups with 4-member limit
- Quest: location-based adventures with riddles
- Riddle: GPS challenges with lat/lng coordinates
- API: standardized response handling